### PR TITLE
Stale Repos Report

### DIFF
--- a/stale_repos.json
+++ b/stale_repos.json
@@ -1,0 +1,1 @@
+[{"url": "https://github.com/barrosoj/barrosoj.github.io", "daysInactive": 57, "lastPushDate": "2023-06-29"}, {"url": "https://github.com/barrosoj/pythonProj", "daysInactive": 820, "lastPushDate": "2021-05-27"}]

--- a/stale_repos.md
+++ b/stale_repos.md
@@ -5,6 +5,4 @@ The following repos have not had a push event for more than 30 days:
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
 | https://github.com/barrosoj/pythonProj | 820 | 2021-05-27 |
-| https://github.com/barrosoj/actions-fundamentals-nos | 58 | 2023-06-27 |
-| https://github.com/barrosoj/barrosoj.github.io | 56 | 2023-06-29 |
-| https://github.com/barrosoj/content-github-actions-deep-dive-lesson | 55 | 2023-06-30 |
+| https://github.com/barrosoj/barrosoj.github.io | 57 | 2023-06-29 |


### PR DESCRIPTION
# Inactive Repositories

The following repos have not had a push event for more than 30 days:

| Repository URL | Days Inactive | Last Push Date |
| --- | --- | ---: |
| https://github.com/barrosoj/pythonProj | 820 | 2021-05-27 |
| https://github.com/barrosoj/barrosoj.github.io | 57 | 2023-06-29 |
